### PR TITLE
Auto-detect columns to wrap usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,10 +492,11 @@ If `key` is an Array, interpret all the elements as strings.
 Tells the parser to interpret `key` as a path to a JSON config file. The file
 is loaded and parsed, and its properties are set as arguments.
 
-.wrap(columns)
+.wrap([columns])
 --------------
 
-Format usage output to wrap at `columns` many columns.
+Format usage output to wrap at `columns` many columns (auto-detect or 80 if not
+specified).
 
 .strict()
 ---------

--- a/index.js
+++ b/index.js
@@ -260,6 +260,10 @@ function Argv (processArgs, cwd) {
 
     var wrap = null;
     self.wrap = function (cols) {
+        if (!cols) {
+            var size = require('window-size');
+            cols = Math.min(size && size.width || 80, 100);
+        }
         wrap = cols;
         return self;
     };
@@ -269,7 +273,7 @@ function Argv (processArgs, cwd) {
         strict = true;
         return self;
     };
-    
+
     self.showHelp = function (fn) {
         if (!fn) fn = console.error.bind(console);
         fn(self.help());

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "1.3.1",
   "description": "Light-weight option parsing with an argv hash. No optstrings attached.",
   "main": "./index.js",
-  "dependencies": {},
+  "dependencies": {
+    "window-size": "^0.1.0"
+  },
   "devDependencies": {
     "hashish": "*",
     "mocha": "*",


### PR DESCRIPTION
This commit adds support for `.wrap()` without the number of columns
specified using the `window-size` package to auto-detect the terminal
width:

https://github.com/jonschlinkert/window-size