### PR TITLE
flags explicitly set as strings, will now default to '' if no right-hand-value is set

### DIFF
--- a/lib/minimist.js
+++ b/lib/minimist.js
@@ -81,7 +81,6 @@ module.exports = function (args, opts) {
     }
 
     function setArg (key, val) {
-
         // handle parsing boolean arguments --foo=true --bar false.
         if (flags.bools[key] || (aliases[key] ? flags.bools[aliases[key]] : false)) {
           if (typeof val === 'string') val = val === 'true';
@@ -163,7 +162,7 @@ module.exports = function (args, opts) {
                 i++;
             }
             else {
-                setArg(key, true);
+                setArg(key, defaultForType(guessType(key, flags)));
             }
         }
         else if (arg.match(/^-[^-]+/)) {
@@ -197,7 +196,7 @@ module.exports = function (args, opts) {
                     break;
                 }
                 else {
-                    setArg(letters[j], true);
+                    setArg(letters[j], defaultForType(guessType(letters[j], flags)));
                 }
             }
 
@@ -214,7 +213,7 @@ module.exports = function (args, opts) {
                     i++;
                 }
                 else {
-                    setArg(key, true);
+                    setArg(key, defaultForType(guessType(key, flags)));
                 }
             }
         }
@@ -281,6 +280,25 @@ function setKey (obj, keys, value) {
     else {
         o[key] = [ o[key], value ];
     }
+}
+
+// return a default value, given the type of a flag.,
+// e.g., key of type 'string' will default to '', rather than 'true'.
+function defaultForType (type) {
+    var def = {
+        boolean: true,
+        string: ''
+    };
+
+    return def[type];
+}
+
+// given a flag, enforce a default type.
+function guessType (key, flags) {
+    var type = 'boolean';
+    if (flags.strings && flags.strings[key]) type = 'string';
+
+    return type;
 }
 
 function isNumber (x) {

--- a/test/parse.js
+++ b/test/parse.js
@@ -198,6 +198,18 @@ describe('parse', function () {
         x.should.be.a('string').and.equal('56');
     });
 
+    // Fixes: https://github.com/chevex/yargs/issues/68
+    it('should parse flag arguments with no right-hand-value as strings, if defined as strings' , function () {
+        var s = yargs([ '-s' ]).string('s').argv.s;
+        s.should.be.a('string').and.equal('');
+
+        s = yargs([ '-sf' ]).string('s').argv.s;
+        s.should.be.a('string').and.equal('');
+
+        s = yargs([ '--string' ]).string('string').argv.string;
+        s.should.be.a('string').and.equal('');
+    });
+
     it('should leave all non-hyphenated values as strings if _ is defined as a string', function () {
         var s = yargs([ '  ', '  ' ]).string('_').argv._;
         s.should.have.length(2);


### PR DESCRIPTION
see #68, the following:

```javascript
var s = yargs([ '-s' ]).string('s').argv.s;
```
will now return an empty string.