### PR TITLE
make `default` option work for specifying a config-path

### DIFF
--- a/lib/minimist.js
+++ b/lib/minimist.js
@@ -99,18 +99,6 @@ module.exports = function (args, opts) {
             value = function(orig) { return orig !== undefined ? orig + 1 : 0; };
         }
 
-        if (flags.configs[key]) {
-            try {
-                var config = JSON.parse(fs.readFileSync(val, 'utf8'));
-                Object.keys(config).forEach(function (key) {
-                    setArg(key, config[key]);
-                });
-            } catch (ex) {
-                console.error('Invalid JSON config file: ' + val);
-                throw ex;
-            }
-        }
-
         setKey(argv, key.split('.'), value);
 
         (aliases[key] || []).forEach(function (x) {
@@ -133,6 +121,25 @@ module.exports = function (args, opts) {
                 break;
             }
         }
+    }
+
+    // set args from config.json file, this should be
+    // applied last so that defaults can be applied.
+    function setConfig (argv) {
+        Object.keys(flags.configs).forEach(function(configKey) {
+            var configPath = argv[configKey];
+            if (configPath) {
+              try {
+                  var config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+                  Object.keys(config).forEach(function (key) {
+                      setArg(key, config[key]);
+                  });
+              } catch (ex) {
+                  console.error('Invalid JSON config file: ' + configPath);
+                  throw ex;
+              }
+            }
+        });
     }
 
     for (var i = 0; i < args.length; i++) {
@@ -238,6 +245,8 @@ module.exports = function (args, opts) {
     Object.keys(flags.counts).forEach(function (key) {
         setArg(key, defaults[key]);
     });
+
+    setConfig(argv);
 
     notFlags.forEach(function(key) {
         argv._.push(key);

--- a/test/parse.js
+++ b/test/parse.js
@@ -238,17 +238,29 @@ describe('parse', function () {
         argv.should.have.property('f', 11);
     });
 
-    /*
-     *it('should load options and values from a file when config is used', function () {
-     *    var argv = yargs([ '--settings', '../test/config.json', '--foo', 'bar' ])
-     *        .alias('z', 'zoom')
-     *        .config('settings')
-     *        .argv;
-     *    argv.should.have.property('herp', 'derp');
-     *    argv.should.have.property('zoom', 55);
-     *    argv.should.have.property('foo').and.deep.equal(['baz','bar']);
-     *});
-     */
+    it('should load options and values from a file when config is used', function () {
+        var argv = yargs([ '--settings', path.resolve(__dirname, './config.json'), '--foo', 'bar' ])
+            .alias('z', 'zoom')
+            .config('settings')
+            .argv;
+
+        argv.should.have.property('herp', 'derp');
+        argv.should.have.property('zoom', 55);
+        argv.should.have.property('foo').and.deep.equal(['bar', 'baz']);
+    });
+
+    // See: https://github.com/chevex/yargs/issues/12
+    it('should load options and values from default config if specified', function () {
+        var argv = yargs([ '--foo', 'bar' ])
+            .alias('z', 'zoom')
+            .config('settings')
+            .default('settings', path.resolve(__dirname, './config.json'))
+            .argv;
+
+        argv.should.have.property('herp', 'derp');
+        argv.should.have.property('zoom', 55);
+        argv.should.have.property('foo').and.deep.equal(['bar', 'baz']);
+    });
 
     it('should allow multiple aliases to be specified', function () {
         var argv = yargs([ '-f', '11', '--zoom', '55' ])


### PR DESCRIPTION
`yargs.config("c").describe("c", "Config file path").default("c","config.json")` will now work as expected.

We should probably make this a `2.x.x` release, because it changes the order of `['baz', 'bar']` to `['bar', 'baz']` (in reality, this shouldn't effect anyone unless they're writing really wonky code).