### PR TITLE
yargs version 3.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,8 +485,8 @@ As an example, here's how the npm cli might document some of its commands:
 ```js
 var argv = require('yargs')
   .usage('npm <command>')
-  .command('install', 'install a package!')
-  .command('publish', 'publish a new version of your package')
+  .command('install', 'tis a mighty fine package to install')
+  .command('publish', 'shiver me timbers, should you be sharing all that')
   .argv;
 ```
 
@@ -516,7 +516,7 @@ Check that certain conditions are met in the provided arguments.
 
 `fn` is called with two arguments, the parsed `argv` hash and an array of options and their aliases.
 
-If `fn` throws or returns `false`, show the thrown error, usage information, and
+If `fn` throws or returns a non-truthy value, show the thrown error, usage information, and
 exit.
 
 .fail(fn)

--- a/README.md
+++ b/README.md
@@ -475,6 +475,21 @@ present script similar to how `$0` works in bash or perl.
 
 `opts` is optional and acts like calling `.options(opts)`.
 
+.command(cmd, desc)
+-------------------
+
+Document the commands exposed by your application (stored in the `_` variable).
+
+As an example, here's how the npm cli might document some of its commands:
+
+```js
+var argv = require('yargs')
+  .usage('npm <command>')
+  .command('install', 'install a package!')
+  .command('publish', 'publish a new version of your package')
+  .argv;
+```
+
 .example(cmd, desc)
 -------------------
 
@@ -482,6 +497,17 @@ Give some example invocations of your program. Inside `cmd`, the string
 `$0` will get interpolated to the current script name or node command for the
 present script similar to how `$0` works in bash or perl.
 Examples will be printed out as part of the help message.
+
+
+.epilogue(str)
+--------------
+
+A message to print at the end of the usage instructions, e.g.,
+
+```js
+var argv = require('yargs')
+  .epilogue('for more information, find our manual at http://example.com');
+```
 
 .check(fn)
 ----------
@@ -522,6 +548,12 @@ If `key` is an Array, interpret all the elements as strings.
 `.string('_')` will result in non-hyphenated arguments being interpreted as strings,
 regardless of whether they resemble numbers.
 
+.array(key)
+----------
+
+Tell the parser to interpret `key` as an array. If `.array('foo')` is set,
+`--foo bar` will be parsed as `['bar']` rather than as `'bar'`.
+
 .config(key)
 ------------
 
@@ -532,6 +564,9 @@ is loaded and parsed, and its properties are set as arguments.
 --------------
 
 Format usage output to wrap at `columns` many columns.
+
+By default wrap will be set to `Math.min(80, windowWidth)`. Use `.wrap(null)` to
+specify no column limit.
 
 .strict()
 ---------

--- a/README.md
+++ b/README.md
@@ -501,6 +501,8 @@ Examples will be printed out as part of the help message.
 
 .epilogue(str)
 --------------
+.epilog(str)
+------------
 
 A message to print at the end of the usage instructions, e.g.,
 

--- a/example/complex.js
+++ b/example/complex.js
@@ -1,0 +1,33 @@
+// a fairly complex CLI defined using the yargs 3.0 API:
+var argv = require('yargs')
+  .usage('Usage: $0 <cmd> [options]') // usage string of application.
+  .command('install', 'install a package (name@version)') // describe commands available.
+  .command('publish', 'publish the package inside the current working directory')
+  .option('f', { // document options.
+    array: true, // even single values will be wrapped in [].
+    description: 'an array of files',
+    default: 'test.js',
+    alias: 'file'
+  })
+  .alias('f', 'fil')
+  .option('h', {
+    alias: 'help',
+    description: 'display help message'
+  })
+  .string(['user', 'pass'])
+  .implies('user', 'pass') // if 'user' is set 'pass' must be set.
+  .help('help')
+  .demand('q') // fail if 'q' not provided.
+  .version('1.0.1', 'version', 'display version information') // the version string.
+  .alias('version', 'v')
+  // show examples of application in action.
+  .example('npm install npm@latest -g', 'install the latest version of npm')
+  // final message to display when successful.
+  .epilog('for more information visit https://github.com/chevex/yargs')
+  // disable showing help on failures, provide a final message
+  // to display for errors.
+  .showHelpOnFail(false, 'whoops, something went wrong! run with --help')
+  .argv;
+
+// the parsed data is stored in argv.
+console.log(argv);

--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ function Argv (processArgs, cwd) {
 
     var examples = [];
     self.example = function (cmd, description) {
-        examples.push([cmd, description]);
+        examples.push([cmd, description || '']);
         return self;
     };
     self.getExamples = function() {

--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ function Argv (processArgs, cwd) {
 
         Object.keys(argv).forEach(function(key) {
             if (key === helpOpt) {
-                self.showHelp(console.log);
+                self.showHelp('log');
                 if (exitProcess){
                     process.exit(0);
                 }

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -6,7 +6,11 @@ var fs = require('fs');
 module.exports = function (args, opts) {
     if (!opts) opts = {};
 
-    var flags = { bools : {}, strings : {}, counts: {}, normalize: {}, configs: {} };
+    var flags = { arrays: {}, bools : {}, strings : {}, counts: {}, normalize: {}, configs: {} };
+
+    [].concat(opts['array']).filter(Boolean).forEach(function (key) {
+        flags.arrays[key] = true;
+    });
 
     [].concat(opts['boolean']).filter(Boolean).forEach(function (key) {
         flags.bools[key] = true;
@@ -82,9 +86,108 @@ module.exports = function (args, opts) {
         args = args.slice(0, args.indexOf('--'));
     }
 
+    for (var i = 0; i < args.length; i++) {
+        var arg = args[i];
+
+        if (arg.match(/^--.+=/)) {
+            // Using [\s\S] instead of . because js doesn't support the
+            // 'dotall' regex modifier. See:
+            // http://stackoverflow.com/a/1068308/13216
+            var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
+            setArg(m[1], m[2]);
+        }
+        else if (arg.match(/^--no-.+/)) {
+            var key = arg.match(/^--no-(.+)/)[1];
+            setArg(key, false);
+        }
+        else if (arg.match(/^--.+/)) {
+            var key = arg.match(/^--(.+)/)[1];
+            var next = args[i + 1];
+            if (next !== undefined && !next.match(/^-/)
+                && !checkAllAliases(key, flags.bools)) {
+                setArg(key, next);
+                i++;
+            }
+            else if (/^(true|false)$/.test(next)) {
+                setArg(key, next);
+                i++;
+            }
+            else {
+                setArg(key, defaultForType(guessType(key, flags)));
+            }
+        }
+        else if (arg.match(/^-[^-]+/)) {
+            var letters = arg.slice(1,-1).split('');
+
+            var broken = false;
+            for (var j = 0; j < letters.length; j++) {
+                var next = arg.slice(j+2);
+
+                if (letters[j+1] && letters[j+1] === '=') {
+                    setArg(letters[j], arg.slice(j+3));
+                    broken = true;
+                    break;
+                }
+
+                if (next === '-') {
+                    setArg(letters[j], next)
+                    continue;
+                }
+
+                if (/[A-Za-z]/.test(letters[j])
+                    && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
+                    setArg(letters[j], next);
+                    broken = true;
+                    break;
+                }
+
+                if (letters[j+1] && letters[j+1].match(/\W/)) {
+                    setArg(letters[j], arg.slice(j+2));
+                    broken = true;
+                    break;
+                }
+                else {
+                    setArg(letters[j], defaultForType(guessType(letters[j], flags)));
+                }
+            }
+
+            var key = arg.slice(-1)[0];
+            if (!broken && key !== '-') {
+                if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
+                    && !checkAllAliases(key, flags.bools)) {
+                    setArg(key, args[i+1]);
+                    i++;
+                }
+                else if (args[i+1] && /true|false/.test(args[i+1])) {
+                    setArg(key, args[i+1]);
+                    i++;
+                }
+                else {
+                    setArg(key, defaultForType(guessType(key, flags)));
+                }
+            }
+        }
+        else {
+            argv._.push(
+                flags.strings['_'] || !isNumber(arg) ? arg : Number(arg)
+            );
+        }
+    }
+
+    setConfig(argv);
+    applyDefaultsAndAliases(argv, aliases, defaults);
+
+    Object.keys(flags.counts).forEach(function (key) {
+        setArg(key, defaults[key]);
+    });
+
+    notFlags.forEach(function(key) {
+        argv._.push(key);
+    });
+
     function setArg (key, val) {
         // handle parsing boolean arguments --foo=true --bar false.
-        if (flags.bools[key] || (aliases[key] ? flags.bools[aliases[key]] : false)) {
+        if (checkAllAliases(key, flags.bools)) {
           if (typeof val === 'string') val = val === 'true';
         }
 
@@ -94,9 +197,9 @@ module.exports = function (args, opts) {
             newAliases[c] = true;
         }
 
-        var value = !flags.strings[key] && isNumber(val) ? Number(val) : val;
+        var value = !checkAllAliases(key, flags.strings) && isNumber(val) ? Number(val) : val;
 
-        if (flags.counts[key] || flags.counts[aliases[key]]) {
+        if (checkAllAliases(key, flags.counts)) {
             value = function(orig) { return orig !== undefined ? orig + 1 : 0; };
         }
 
@@ -153,106 +256,92 @@ module.exports = function (args, opts) {
         });
     }
 
-    for (var i = 0; i < args.length; i++) {
-        var arg = args[i];
+    function applyDefaultsAndAliases(obj, aliases, defaults) {
+        Object.keys(defaults).forEach(function (key) {
+            if (!hasKey(obj, key.split('.'))) {
+                setKey(obj, key.split('.'), defaults[key]);
 
-        if (arg.match(/^--.+=/)) {
-            // Using [\s\S] instead of . because js doesn't support the
-            // 'dotall' regex modifier. See:
-            // http://stackoverflow.com/a/1068308/13216
-            var m = arg.match(/^--([^=]+)=([\s\S]*)$/);
-            setArg(m[1], m[2]);
+                (aliases[key] || []).forEach(function (x) {
+                    setKey(obj, x.split('.'), defaults[key]);
+                });
+            }
+        });
+    }
+
+    function hasKey (obj, keys) {
+        var o = obj;
+        keys.slice(0,-1).forEach(function (key) {
+            o = (o[key] || {});
+        });
+
+        var key = keys[keys.length - 1];
+        return key in o;
+    }
+
+    function setKey (obj, keys, value) {
+        var o = obj;
+        keys.slice(0,-1).forEach(function (key) {
+            if (o[key] === undefined) o[key] = {};
+            o = o[key];
+        });
+
+        var key = keys[keys.length - 1];
+        if (typeof value === 'function') {
+            o[key] = value(o[key]);
         }
-        else if (arg.match(/^--no-.+/)) {
-            var key = arg.match(/^--no-(.+)/)[1];
-            setArg(key, false);
+        else if (o[key] === undefined && checkAllAliases(key, flags.arrays)) {
+            o[key] = Array.isArray(value) ? value : [value];
         }
-        else if (arg.match(/^--.+/)) {
-            var key = arg.match(/^--(.+)/)[1];
-            var next = args[i + 1];
-            if (next !== undefined && !next.match(/^-/)
-                && !flags.bools[key]
-                && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
-                setArg(key, next);
-                i++;
-            }
-            else if (/^(true|false)$/.test(next)) {
-                setArg(key, next);
-                i++;
-            }
-            else {
-                setArg(key, defaultForType(guessType(key, flags)));
-            }
+        else if (o[key] === undefined || typeof o[key] === 'boolean') {
+            o[key] = value;
         }
-        else if (arg.match(/^-[^-]+/)) {
-            var letters = arg.slice(1,-1).split('');
-
-            var broken = false;
-            for (var j = 0; j < letters.length; j++) {
-                var next = arg.slice(j+2);
-
-                if (letters[j+1] && letters[j+1] === '=') {
-                    setArg(letters[j], arg.slice(j+3));
-                    broken = true;
-                    break;
-                }
-
-                if (next === '-') {
-                    setArg(letters[j], next)
-                    continue;
-                }
-
-                if (/[A-Za-z]/.test(letters[j])
-                    && /-?\d+(\.\d*)?(e-?\d+)?$/.test(next)) {
-                    setArg(letters[j], next);
-                    broken = true;
-                    break;
-                }
-
-                if (letters[j+1] && letters[j+1].match(/\W/)) {
-                    setArg(letters[j], arg.slice(j+2));
-                    broken = true;
-                    break;
-                }
-                else {
-                    setArg(letters[j], defaultForType(guessType(letters[j], flags)));
-                }
-            }
-
-            var key = arg.slice(-1)[0];
-            if (!broken && key !== '-') {
-                if (args[i+1] && !/^(-|--)[^-]/.test(args[i+1])
-                    && !flags.bools[key]
-                    && (aliases[key] ? !flags.bools[aliases[key]] : true)) {
-                    setArg(key, args[i+1]);
-                    i++;
-                }
-                else if (args[i+1] && /true|false/.test(args[i+1])) {
-                    setArg(key, args[i+1]);
-                    i++;
-                }
-                else {
-                    setArg(key, defaultForType(guessType(key, flags)));
-                }
-            }
+        else if (Array.isArray(o[key])) {
+            o[key].push(value);
         }
         else {
-            argv._.push(
-                flags.strings['_'] || !isNumber(arg) ? arg : Number(arg)
-            );
+            o[key] = [ o[key], value ];
         }
     }
 
-    setConfig(argv);
-    applyDefaultsAndAliases(argv, aliases, defaults);
+    // check if a flag is set for any of a key's aliases.
+    function checkAllAliases (key, flag) {
+        var isSet = false,
+          toCheck = [].concat(aliases[key] || [], key);
 
-    Object.keys(flags.counts).forEach(function (key) {
-        setArg(key, defaults[key]);
-    });
+        toCheck.forEach(function(key) {
+            if (flag[key]) isSet = true;
+        });
 
-    notFlags.forEach(function(key) {
-        argv._.push(key);
-    });
+        return isSet;
+    };
+
+    // return a default value, given the type of a flag.,
+    // e.g., key of type 'string' will default to '', rather than 'true'.
+    function defaultForType (type) {
+        var def = {
+            boolean: true,
+            string: '',
+            array: []
+        };
+
+        return def[type];
+    }
+
+    // given a flag, enforce a default type.
+    function guessType (key, flags) {
+        var type = 'boolean';
+
+        if (flags.strings && flags.strings[key]) type = 'string';
+        else if (flags.arrays && flags.arrays[key]) type = 'array';
+
+        return type;
+    }
+
+    function isNumber (x) {
+        if (typeof x === 'number') return true;
+        if (/^0x[0-9a-f]+$/i.test(x)) return true;
+        return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x);
+    }
 
     return {
         argv: argv,
@@ -260,72 +349,3 @@ module.exports = function (args, opts) {
         newAliases: newAliases
     };
 };
-
-function applyDefaultsAndAliases(obj, aliases, defaults) {
-    Object.keys(defaults).forEach(function (key) {
-        if (!hasKey(obj, key.split('.'))) {
-            setKey(obj, key.split('.'), defaults[key]);
-
-            (aliases[key] || []).forEach(function (x) {
-                setKey(obj, x.split('.'), defaults[key]);
-            });
-        }
-    });
-}
-
-function hasKey (obj, keys) {
-    var o = obj;
-    keys.slice(0,-1).forEach(function (key) {
-        o = (o[key] || {});
-    });
-
-    var key = keys[keys.length - 1];
-    return key in o;
-}
-
-function setKey (obj, keys, value) {
-    var o = obj;
-    keys.slice(0,-1).forEach(function (key) {
-        if (o[key] === undefined) o[key] = {};
-        o = o[key];
-    });
-
-    var key = keys[keys.length - 1];
-    if (typeof value === 'function') {
-        o[key] = value(o[key]);
-    }
-    else if (o[key] === undefined || typeof o[key] === 'boolean') {
-        o[key] = value;
-    }
-    else if (Array.isArray(o[key])) {
-        o[key].push(value);
-    }
-    else {
-        o[key] = [ o[key], value ];
-    }
-}
-
-// return a default value, given the type of a flag.,
-// e.g., key of type 'string' will default to '', rather than 'true'.
-function defaultForType (type) {
-    var def = {
-        boolean: true,
-        string: ''
-    };
-
-    return def[type];
-}
-
-// given a flag, enforce a default type.
-function guessType (key, flags) {
-    var type = 'boolean';
-    if (flags.strings && flags.strings[key]) type = 'string';
-
-    return type;
-}
-
-function isNumber (x) {
-    if (typeof x === 'number') return true;
-    if (/^0x[0-9a-f]+$/i.test(x)) return true;
-    return /^[-+]?(?:\d+(?:\.\d*)?|\.\d+)(e[-+]?\d+)?$/.test(x);
-}

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -3,9 +3,7 @@
 var wordwrap = require('wordwrap'),
   wsize = require('window-size');
 
-module.exports = Usage;
-
-function Usage (yargs) {
+module.exports = function (yargs) {
     var self = {};
 
     // methods for ouputting/building failure message.
@@ -235,12 +233,9 @@ function Usage (yargs) {
         );
     }
 
-    // guess the width of the console window.
+    // guess the width of the console window, max-width 100.
     function windowWidth() {
-        var wsizeMax = 80;
-
-        if (!wsize.width) return null;
-        else return Math.min(100, wsize.width);
+        return wsize.width ? Math.min(100, wsize.width) : null;
     }
 
     // logic for displaying application version.

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -201,9 +201,9 @@ function Usage (yargs) {
         return help.join('\n');
     };
 
-    self.showHelp = function (fn) {
-        if (!fn) fn = console.error.bind(console);
-        fn(self.help());
+    self.showHelp = function (level) {
+        level = level || 'error';
+        console[level](self.help());
     }
 
     function longest (xs) {
@@ -220,7 +220,7 @@ function Usage (yargs) {
     };
 
     self.showVersion = function() {
-        console.info(version);
+        console.log(version);
     };
 
     return self;

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,6 +1,7 @@
 // this file handles outputting usage instructions,
 // failures, etc. keeps logging in one place.
-var wordwrap = require('wordwrap');
+var wordwrap = require('wordwrap'),
+  wsize = require('window-size');
 
 module.exports = Usage;
 
@@ -58,7 +59,7 @@ function Usage (yargs) {
         usage = msg;
     };
 
-    var wrap = null;
+    var wrap = windowWidth();
     self.wrap = function (cols) {
         wrap = cols;
     };
@@ -100,7 +101,9 @@ function Usage (yargs) {
         }
 
         if (usage) {
-            help.unshift(usage.replace(/\$0/g, yargs.$0), '');
+            var u = usage.replace(/\$0/g, yargs.$0);
+            if (wrap) u = wordwrap(0, wrap)(u);
+            help.unshift(u, '');
         }
 
         var aliasKeys = (Object.keys(options.alias) || [])
@@ -230,6 +233,14 @@ function Usage (yargs) {
             null,
             xs.map(function (x) { return x.length })
         );
+    }
+
+    // guess the width of the console window.
+    function windowWidth() {
+        var wsizeMax = 80;
+
+        if (!wsize.width) return null;
+        else return Math.min(100, wsize.width);
     }
 
     // logic for displaying application version.

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -86,19 +86,16 @@ function Usage (yargs) {
                 example[0] = example[0].replace(/\$0/g, yargs.$0);
             });
 
-            var commandlen = longest(examples.map(function (a) {
-                return a[0];
-            }));
-
-            var exampleLines = examples.map(function(example) {
-                var command = example[0];
-                var description = example[1];
-                command += Array(commandlen + 5 - command.length).join(' ');
-                return '  ' + command + description;
+            var examplesTable = {};
+            examples.forEach(function(example) {
+                examplesTable[example[0]] = {
+                    desc: example[1],
+                    extra: ''
+                };
             });
 
-            exampleLines.push('');
-            help = exampleLines.concat(help);
+            help = formatTable(examplesTable, 5).concat(help);
+            help.push('');
             help.unshift('Examples:');
         }
 
@@ -114,6 +111,7 @@ function Usage (yargs) {
                 return -1 == (options.alias[alias] || []).indexOf(key);
             });
         });
+
         var switches = keys.reduce(function (acc, key) {
             acc[key] = [ key ].concat(options.alias[key] || [])
                 .map(function (sw) {
@@ -124,32 +122,10 @@ function Usage (yargs) {
             return acc;
         }, {});
 
-        var switchlen = longest(Object.keys(switches).map(function (s) {
-            return switches[s] || '';
-        }));
-
-        var desclen = longest(Object.keys(descriptions).map(function (d) {
-            return descriptions[d] || '';
-        }));
-
+        var switchTable = {};
         keys.forEach(function (key) {
             var kswitch = switches[key];
             var desc = descriptions[key] || '';
-
-            if (wrap) {
-                desc = wordwrap(switchlen + 4, wrap)(desc)
-                    .slice(switchlen + 4)
-                ;
-            }
-
-            var spadding = new Array(
-                Math.max(switchlen - kswitch.length + 3, 0)
-            ).join(' ');
-
-            var dpadding = new Array(
-                Math.max(desclen - desc.length + 1, 0)
-            ).join(' ');
-
             var type = null;
 
             if (options.boolean[key]) type = '[boolean]';
@@ -157,11 +133,6 @@ function Usage (yargs) {
             if (options.string[key]) type = '[string]';
             if (options.normalize[key]) type = '[string]';
 
-            if (!wrap && dpadding.length > 0) {
-                desc += dpadding;
-            }
-
-            var prelude = '  ' + kswitch + spadding;
             var extra = [
                 type,
                 demanded[key]
@@ -174,6 +145,59 @@ function Usage (yargs) {
                     : null
             ].filter(Boolean).join('  ');
 
+            switchTable[kswitch] = {
+              desc: desc,
+              extra: extra
+            };
+        });
+        help.push.apply(help, formatTable(switchTable, 3));
+
+        if (keys.length) help.push('');
+        return help.join('\n');
+    };
+
+    self.showHelp = function (level) {
+        level = level || 'error';
+        console[level](self.help());
+    }
+
+    // word-wrapped two-column layout used by
+    // examples and options.
+    function formatTable (table, padding) {
+        var output = [];
+
+        // determine lengths of left column, and
+        // description column.
+        var llen = longest(Object.keys(table));
+
+        var desclen = longest(Object.keys(table).map(function (k) {
+            return table[k].desc;
+        }));
+
+        Object.keys(table).forEach(function(left) {
+            var desc = table[left].desc,
+              extra = table[left].extra;
+
+            if (wrap) {
+                desc = wordwrap(llen + padding + 1, wrap)(desc)
+                    .slice(llen + padding + 1)
+                ;
+            }
+
+            var lpadding = new Array(
+                Math.max(llen - left.length + padding, 0)
+            ).join(' ');
+
+            var dpadding = new Array(
+                Math.max(desclen - desc.length + 1, 0)
+            ).join(' ');
+
+            if (!wrap && dpadding.length > 0) {
+                desc += dpadding;
+            }
+
+            var prelude = '  ' + left + lpadding;
+
             var body = [ desc, extra ].filter(Boolean).join('  ');
 
             if (wrap) {
@@ -182,7 +206,7 @@ function Usage (yargs) {
                     + (dlines.length === 1 ? prelude.length : 0)
 
                 if (extra.length > wrap) {
-                    body = desc + '\n' + wordwrap(switchlen + 4, wrap)(extra)
+                    body = desc + '\n' + wordwrap(llen + 4, wrap)(extra)
                 } else {
                     body = desc + (dlen + extra.length > wrap - 2
                         ? '\n'
@@ -194,18 +218,13 @@ function Usage (yargs) {
                 }
             }
 
-            help.push(prelude + body);
+            output.push(prelude + body);
         });
 
-        if (keys.length) help.push('');
-        return help.join('\n');
-    };
-
-    self.showHelp = function (level) {
-        level = level || 'error';
-        console[level](self.help());
+        return output;
     }
 
+    // find longest string in array of strings.
     function longest (xs) {
         return Math.max.apply(
             null,

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -1,0 +1,227 @@
+// this file handles outputting usage instructions,
+// failures, etc. keeps logging in one place.
+var wordwrap = require('wordwrap');
+
+module.exports = Usage;
+
+function Usage (yargs) {
+    var self = {};
+
+    // methods for ouputting/building failure message.
+    var fails = [];
+    self.failFn = function (f) {
+        fails.push(f);
+    };
+
+    var failMessage = null;
+    var showHelpOnFail = true;
+    self.showHelpOnFail = function (enabled, message) {
+        if (typeof enabled === 'string') {
+            message = enabled;
+            enabled = true;
+        }
+        else if (typeof enabled === 'undefined') {
+            enabled = true;
+        }
+        failMessage = message;
+        showHelpOnFail = enabled;
+        return self;
+    };
+
+    self.fail = function (msg) {
+        if (fails.length) {
+            fails.forEach(function (f) {
+                f(msg);
+            });
+        } else {
+            if (showHelpOnFail) {
+                yargs.showHelp();
+            }
+            if (msg) console.error(msg);
+            if (failMessage) {
+                if (msg) {
+                    console.error("");
+                }
+                console.error(failMessage);
+            }
+            if (yargs.getExitProcess()){
+                process.exit(1);
+            }else{
+                throw new Error(msg);
+            }
+        }
+    };
+
+    // methods for ouputting/building help (usage) message.
+    var usage;
+    self.usage = function (msg) {
+        usage = msg;
+    };
+
+    var wrap = null;
+    self.wrap = function (cols) {
+        wrap = cols;
+    };
+
+    self.help = function () {
+        var descriptions = yargs.getDescriptions(),
+            demanded = yargs.getDemanded(),
+            examples = yargs.getExamples(),
+            options = yargs.getOptions(),
+            keys = Object.keys(
+                Object.keys(descriptions)
+                .concat(Object.keys(demanded))
+                .concat(Object.keys(options.default))
+                .reduce(function (acc, key) {
+                    if (key !== '_') acc[key] = true;
+                    return acc;
+                }, {})
+            );
+
+        var help = keys.length ? [ 'Options:' ] : [];
+
+        if (examples.length) {
+            help.unshift('');
+            examples.forEach(function (example) {
+                example[0] = example[0].replace(/\$0/g, yargs.$0);
+            });
+
+            var commandlen = longest(examples.map(function (a) {
+                return a[0];
+            }));
+
+            var exampleLines = examples.map(function(example) {
+                var command = example[0];
+                var description = example[1];
+                command += Array(commandlen + 5 - command.length).join(' ');
+                return '  ' + command + description;
+            });
+
+            exampleLines.push('');
+            help = exampleLines.concat(help);
+            help.unshift('Examples:');
+        }
+
+        if (usage) {
+            help.unshift(usage.replace(/\$0/g, yargs.$0), '');
+        }
+
+        var aliasKeys = (Object.keys(options.alias) || [])
+            .concat(Object.keys(yargs.parsed.newAliases) || []);
+
+        keys = keys.filter(function(key) {
+            return !yargs.parsed.newAliases[key] && aliasKeys.every(function(alias) {
+                return -1 == (options.alias[alias] || []).indexOf(key);
+            });
+        });
+        var switches = keys.reduce(function (acc, key) {
+            acc[key] = [ key ].concat(options.alias[key] || [])
+                .map(function (sw) {
+                    return (sw.length > 1 ? '--' : '-') + sw
+                })
+                .join(', ')
+            ;
+            return acc;
+        }, {});
+
+        var switchlen = longest(Object.keys(switches).map(function (s) {
+            return switches[s] || '';
+        }));
+
+        var desclen = longest(Object.keys(descriptions).map(function (d) {
+            return descriptions[d] || '';
+        }));
+
+        keys.forEach(function (key) {
+            var kswitch = switches[key];
+            var desc = descriptions[key] || '';
+
+            if (wrap) {
+                desc = wordwrap(switchlen + 4, wrap)(desc)
+                    .slice(switchlen + 4)
+                ;
+            }
+
+            var spadding = new Array(
+                Math.max(switchlen - kswitch.length + 3, 0)
+            ).join(' ');
+
+            var dpadding = new Array(
+                Math.max(desclen - desc.length + 1, 0)
+            ).join(' ');
+
+            var type = null;
+
+            if (options.boolean[key]) type = '[boolean]';
+            if (options.count[key]) type = '[count]';
+            if (options.string[key]) type = '[string]';
+            if (options.normalize[key]) type = '[string]';
+
+            if (!wrap && dpadding.length > 0) {
+                desc += dpadding;
+            }
+
+            var prelude = '  ' + kswitch + spadding;
+            var extra = [
+                type,
+                demanded[key]
+                    ? '[required]'
+                    : null
+                ,
+                options.default[key] !== undefined
+                    ? '[default: ' + (typeof options.default[key] === 'string' ?
+                    JSON.stringify : String)(options.default[key]) + ']'
+                    : null
+            ].filter(Boolean).join('  ');
+
+            var body = [ desc, extra ].filter(Boolean).join('  ');
+
+            if (wrap) {
+                var dlines = desc.split('\n');
+                var dlen = dlines.slice(-1)[0].length
+                    + (dlines.length === 1 ? prelude.length : 0)
+
+                if (extra.length > wrap) {
+                    body = desc + '\n' + wordwrap(switchlen + 4, wrap)(extra)
+                } else {
+                    body = desc + (dlen + extra.length > wrap - 2
+                        ? '\n'
+                            + new Array(wrap - extra.length + 1).join(' ')
+                            + extra
+                        : new Array(wrap - extra.length - dlen + 1).join(' ')
+                            + extra
+                    );
+                }
+            }
+
+            help.push(prelude + body);
+        });
+
+        if (keys.length) help.push('');
+        return help.join('\n');
+    };
+
+    self.showHelp = function (fn) {
+        if (!fn) fn = console.error.bind(console);
+        fn(self.help());
+    }
+
+    function longest (xs) {
+        return Math.max.apply(
+            null,
+            xs.map(function (x) { return x.length })
+        );
+    }
+
+    // logic for displaying application version.
+    var version = null;
+    self.version = function (ver, opt, msg) {
+        version = ver;
+    };
+
+    self.showVersion = function() {
+        console.info(version);
+    };
+
+    return self;
+}

--- a/lib/usage.js
+++ b/lib/usage.js
@@ -34,7 +34,7 @@ module.exports = function (yargs) {
             });
         } else {
             if (showHelpOnFail) {
-                yargs.showHelp();
+                yargs.showHelp("error");
             }
             if (msg) console.error(msg);
             if (failMessage) {
@@ -57,15 +57,43 @@ module.exports = function (yargs) {
         usage = msg;
     };
 
+    var examples = [];
+    self.example = function (cmd, description) {
+        examples.push([cmd, description || '']);
+    };
+
+    var commands = [];
+    self.command = function (cmd, description) {
+        commands.push([cmd, description || '']);
+    };
+
+    var descriptions = {};
+    self.describe = function (key, desc) {
+        if (typeof key === 'object') {
+            Object.keys(key).forEach(function (k) {
+                self.describe(k, key[k]);
+            });
+        }
+        else {
+            descriptions[key] = desc;
+        }
+    };
+    self.getDescriptions = function() {
+        return descriptions;
+    }
+
+    var epilog;
+    self.epilog = function (msg) {
+        epilog = msg;
+    };
+
     var wrap = windowWidth();
     self.wrap = function (cols) {
         wrap = cols;
     };
 
     self.help = function () {
-        var descriptions = yargs.getDescriptions(),
-            demanded = yargs.getDemanded(),
-            examples = yargs.getExamples(),
+        var demanded = yargs.getDemanded(),
             options = yargs.getOptions(),
             keys = Object.keys(
                 Object.keys(descriptions)
@@ -79,31 +107,30 @@ module.exports = function (yargs) {
 
         var help = keys.length ? [ 'Options:' ] : [];
 
-        if (examples.length) {
+        // your application's commands, i.e., non-option
+        // arguments populated in '_'.
+        if (commands.length) {
             help.unshift('');
-            examples.forEach(function (example) {
-                example[0] = example[0].replace(/\$0/g, yargs.$0);
-            });
 
-            var examplesTable = {};
-            examples.forEach(function(example) {
-                examplesTable[example[0]] = {
-                    desc: example[1],
+            var commandsTable = {};
+            commands.forEach(function(command) {
+                commandsTable[command[0]] = {
+                    desc: command[1],
                     extra: ''
                 };
             });
 
-            help = formatTable(examplesTable, 5).concat(help);
-            help.push('');
-            help.unshift('Examples:');
+            help = ['Commands:'].concat(formatTable(commandsTable, 5), help);
         }
 
+        // the usage string.
         if (usage) {
             var u = usage.replace(/\$0/g, yargs.$0);
             if (wrap) u = wordwrap(0, wrap)(u);
             help.unshift(u, '');
         }
 
+        // the options table.
         var aliasKeys = (Object.keys(options.alias) || [])
             .concat(Object.keys(yargs.parsed.newAliases) || []);
 
@@ -154,6 +181,31 @@ module.exports = function (yargs) {
         help.push.apply(help, formatTable(switchTable, 3));
 
         if (keys.length) help.push('');
+
+        // describe some common use-cases for your application.
+        if (examples.length) {
+            examples.forEach(function (example) {
+                example[0] = example[0].replace(/\$0/g, yargs.$0);
+            });
+
+            var examplesTable = {};
+            examples.forEach(function(example) {
+                examplesTable[example[0]] = {
+                    desc: example[1],
+                    extra: ''
+                };
+            });
+
+            help.push.apply(help, ['Examples:'].concat(formatTable(examplesTable, 5), ''));
+        }
+
+        // the usage string.
+        if (epilog) {
+            var e = epilog;
+            if (wrap) e = wordwrap(0, wrap)(epilog);
+            help.push(epilog, '');
+        }
+
         return help.join('\n');
     };
 
@@ -163,7 +215,7 @@ module.exports = function (yargs) {
     }
 
     // word-wrapped two-column layout used by
-    // examples and options.
+    // examples, options, commands.
     function formatTable (table, padding) {
         var output = [];
 
@@ -235,7 +287,7 @@ module.exports = function (yargs) {
 
     // guess the width of the console window, max-width 100.
     function windowWidth() {
-        return wsize.width ? Math.min(100, wsize.width) : null;
+        return wsize.width ? Math.min(80, wsize.width) : null;
     }
 
     // logic for displaying application version.

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -112,7 +112,7 @@ module.exports = function (yargs, usage) {
         checks.forEach(function (f) {
             try {
                 var result = f(argv, aliases);
-                if (result === false) {
+                if (!result) {
                     usage.fail('Argument check failed: ' + f.toString());
                 } else if (typeof result === 'string') {
                     usage.fail(result);

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,8 +1,6 @@
 // validation-type-stuff, missing params,
 // bad implications, custom checks.
-module.exports = Validation;
-
-function Validation (yargs, usage) {
+module.exports = function (yargs, usage) {
     var self = {};
 
     // validate appropriate # of non-option

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,0 +1,182 @@
+// validation-type-stuff, missing params,
+// bad implications, custom checks.
+module.exports = Validation;
+
+function Validation (yargs, usage) {
+    var self = {};
+
+    // validate appropriate # of non-option
+    // arguments were provided, i.e., '_'.
+    self.nonOptionCount = function(argv) {
+        var demanded = yargs.getDemanded();
+
+        if (demanded._ && argv._.length < demanded._.count) {
+            if (demanded._.msg) {
+                usage.fail(demanded._.msg);
+            } else {
+                usage.fail('Not enough non-option arguments: got '
+                    + argv._.length + ', need at least ' + demanded._.count
+                );
+            }
+        }
+    };
+
+    // make sure that any args that require an
+    // value (--foo=bar), have a value.
+    self.missingArgumentValue = function(argv) {
+        var options = yargs.getOptions();
+
+        if (options.requiresArg.length > 0) {
+            var missingRequiredArgs = [];
+
+            options.requiresArg.forEach(function(key) {
+                var value = argv[key];
+
+                // parser sets --foo value to true / --no-foo to false
+                if (value === true || value === false) {
+                    missingRequiredArgs.push(key);
+                }
+            });
+
+            if (missingRequiredArgs.length == 1) {
+                usage.fail("Missing argument value: " + missingRequiredArgs[0]);
+            }
+            else if (missingRequiredArgs.length > 1) {
+                var message = "Missing argument values: " + missingRequiredArgs.join(", ");
+                usage.fail(message);
+            }
+        }
+    };
+
+    // make sure all the required arguments are present.
+    self.requiredArguments = function(argv) {
+        var demanded = yargs.getDemanded(),
+          missing = null;
+
+        Object.keys(demanded).forEach(function (key) {
+            if (!argv.hasOwnProperty(key)) {
+                missing = missing || {};
+                missing[key] = demanded[key];
+            }
+        });
+
+        if (missing) {
+            var customMsgs = [];
+            Object.keys(missing).forEach(function(key) {
+                var msg = missing[key].msg;
+                if (msg && customMsgs.indexOf(msg) < 0) {
+                    customMsgs.push(msg);
+                }
+            });
+            var customMsg = customMsgs.length ? '\n' + customMsgs.join('\n') : '';
+
+            usage.fail('Missing required arguments: ' + Object.keys(missing).join(', ') + customMsg);
+        }
+    };
+
+    // check for unknown arguments (strict-mode).
+    self.unknownArguments = function(argv, aliases) {
+        var descriptions = yargs.getDescriptions(),
+          demanded = yargs.getDemanded(),
+          unknown = [],
+          aliasLookup = {};
+
+        Object.keys(aliases).forEach(function (key) {
+            aliases[key].forEach(function (alias) {
+                aliasLookup[alias] = key;
+            });
+        });
+
+        Object.keys(argv).forEach(function (key) {
+            if (key !== "$0" && key !== "_" &&
+                !descriptions.hasOwnProperty(key) &&
+                !demanded.hasOwnProperty(key) &&
+                !aliasLookup.hasOwnProperty(key)) {
+                unknown.push(key);
+            }
+        });
+
+        if (unknown.length == 1) {
+            usage.fail("Unknown argument: " + unknown[0]);
+        }
+        else if (unknown.length > 1) {
+            usage.fail("Unknown arguments: " + unknown.join(", "));
+        }
+    };
+
+    // custom checks, added using the `check` option on yargs.
+    var checks = [];
+    self.check = function (f) {
+        checks.push(f);
+    };
+
+    self.customChecks = function(argv, aliases) {
+        checks.forEach(function (f) {
+            try {
+                var result = f(argv, aliases);
+                if (result === false) {
+                    usage.fail('Argument check failed: ' + f.toString());
+                } else if (typeof result === 'string') {
+                    usage.fail(result);
+                }
+            }
+            catch (err) {
+                usage.fail(err)
+            }
+        });
+    };
+
+    // check implications, argument foo implies => argument bar.
+    self.implications = function(argv) {
+        var implied = yargs.getImplied(),
+          implyFail = [];
+
+        Object.keys(implied).forEach(function (key) {
+            var num, origKey = key, value = implied[key];
+
+            // convert string '1' to number 1
+            var num = Number(key);
+            key = isNaN(num) ? key : num;
+
+            if (typeof key === 'number') {
+                // check length of argv._
+                key = argv._.length >= key;
+            } else if (key.match(/^--no-.+/)) {
+                // check if key doesn't exist
+                key = key.match(/^--no-(.+)/)[1];
+                key = !argv[key];
+            } else {
+                // check if key exists
+                key = argv[key];
+            }
+
+            num = Number(value);
+            value = isNaN(num) ? value : num;
+
+            if (typeof value === 'number') {
+                value = argv._.length >= value;
+            } else if (value.match(/^--no-.+/)) {
+                value = value.match(/^--no-(.+)/)[1];
+                value = !argv[value];
+            } else {
+                value = argv[value];
+            }
+
+            if (key && !value) {
+                implyFail.push(origKey);
+            }
+        });
+
+        if (implyFail.length) {
+            var msg = 'Implications failed:\n';
+
+            implyFail.forEach(function (key) {
+                msg += ('  ' + key + ' -> ' + implied[key] + '\n');
+            });
+
+            usage.fail(msg);
+        }
+    }
+
+    return self;
+}

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -74,7 +74,7 @@ module.exports = function (yargs, usage) {
 
     // check for unknown arguments (strict-mode).
     self.unknownArguments = function(argv, aliases) {
-        var descriptions = yargs.getDescriptions(),
+        var descriptions = usage.getDescriptions(),
           demanded = yargs.getDemanded(),
           unknown = [],
           aliasLookup = {};
@@ -125,9 +125,19 @@ module.exports = function (yargs, usage) {
     };
 
     // check implications, argument foo implies => argument bar.
+    var implied = {};
+    self.implies = function (key, value) {
+        if (typeof key === 'object') {
+            Object.keys(key).forEach(function (k) {
+                self.implies(k, key[k]);
+            });
+        } else {
+            implied[key] = value;
+        }
+    };
+
     self.implications = function(argv) {
-        var implied = yargs.getImplied(),
-          implyFail = [];
+        var implyFail = [];
 
         Object.keys(implied).forEach(function (key) {
             var num, origKey = key, value = implied[key];
@@ -169,7 +179,7 @@ module.exports = function (yargs, usage) {
             var msg = 'Implications failed:\n';
 
             implyFail.forEach(function (key) {
-                msg += ('  ' + key + ' -> ' + implied[key] + '\n');
+                msg += ('  ' + key + ' -> ' + implied[key]);
             });
 
             usage.fail(msg);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "LICENSE"
   ],
   "dependencies": {
+    "window-size": "0.1.0",
     "wordwrap": "0.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yargs",
-  "version": "2.3.0",
+  "version": "3.0.1",
   "description": "Light-weight option parsing with an argv hash. No optstrings attached.",
   "main": "./index.js",
   "files": [

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -4,7 +4,6 @@ var Hash = require('hashish');
 // assert against it.
 exports.checkOutput = function(f) {
     var exit = false,
-      _write = process.stdout.write,
       _exit = process.exit,
       _env = process.env,
       _argv = process.argv,

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -14,7 +14,6 @@ exports.checkOutput = function(f) {
     process.exit = function () { exit = true };
     process.env = Hash.merge(process.env, { _ : 'node' });
     process.argv = [ './usage' ];
-    process.stdout.write = function (msg) { logs.push(msg) }
 
     var errors = [];
     var logs = [];
@@ -27,7 +26,6 @@ exports.checkOutput = function(f) {
     process.exit = _exit;
     process.env = _env;
     process.argv = _argv;
-    process.stdout.write = _write;
 
     console.error = _error;
     console.log = _log;

--- a/test/parser.js
+++ b/test/parser.js
@@ -821,4 +821,30 @@ describe('parser tests', function () {
             parsed.verbose.should.equal(5);
         });
     });
+
+    describe('array', function() {
+        it('should default argument to empty array if no value given', function () {
+            var result = yargs().array('b').parse([ '-b' ]);
+            Array.isArray(result.b).should.equal(true);
+        });
+
+        it('should place value of argument in array, when one argument provided', function() {
+            var result = yargs().array('b').parse(['-b', '33']);
+            Array.isArray(result.b).should.equal(true);
+            result.b[0].should.equal(33);
+        });
+
+        it('should add multiple argument values to the array', function() {
+            var result = yargs().array('b').parse(['-b', '33', '-b', 'hello']);
+            Array.isArray(result.b).should.equal(true);
+            result.b.should.include(33);
+            result.b.should.include('hello');
+        });
+
+        it('should allow array: true, to be set inside an option block', function() {
+            var result = yargs().option('b', {array: true}).parse(['-b', '33']);
+            Array.isArray(result.b).should.equal(true);
+            result.b.should.include(33);
+        });
+    });
 });

--- a/test/usage.js
+++ b/test/usage.js
@@ -690,9 +690,7 @@ describe('usage tests', function () {
             r.should.have.property('errors');
             r.should.have.property('logs').with.length(1);
             r.should.have.property('exit').and.be.ok;
-            r.logs.join('\n').split(/\n+/).should.deep.equal([
-                '1.0.1'
-            ]);
+            r.logs[0].should.eql('1.0.1\n');
         });
     });
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -690,7 +690,7 @@ describe('usage tests', function () {
             r.should.have.property('errors');
             r.should.have.property('logs').with.length(1);
             r.should.have.property('exit').and.be.ok;
-            r.logs[0].should.eql('1.0.1\n');
+            r.logs[0].should.eql('1.0.1');
         });
     });
 

--- a/test/usage.js
+++ b/test/usage.js
@@ -11,6 +11,7 @@ describe('usage tests', function () {
                     return yargs('-x 10 -z 20'.split(' '))
                         .usage('Usage: $0 -x NUM -y NUM')
                         .demand(['x','y'])
+                        .wrap(null)
                         .argv;
                 });
                 r.result.should.have.property('x', 10);
@@ -33,6 +34,7 @@ describe('usage tests', function () {
                         return yargs('-x 10 -z 20'.split(' '))
                             .usage('Usage: $0 -x NUM -y NUM')
                             .require(['x','y'])
+                            .wrap(null)
                             .argv;
                     });
                     r.result.should.have.property('x', 10);
@@ -56,6 +58,7 @@ describe('usage tests', function () {
                 return yargs('-z 20'.split(' '))
                     .usage('Usage: $0 -x NUM -y NUM')
                     .demand(['x','y'], 'x and y are both required to multiply all the things')
+                    .wrap(null)
                     .argv;
             });
             r.result.should.have.property('z', 20);
@@ -77,6 +80,7 @@ describe('usage tests', function () {
                 return yargs('-x 10 -y 20'.split(' '))
                     .usage('Usage: $0 -x NUM -y NUM')
                     .demand(['x','y'])
+                    .wrap(null)
                     .argv;
             });
             r.should.have.property('result');
@@ -308,6 +312,7 @@ describe('usage tests', function () {
                 .alias('f', 'foo')
                 .default('f', 5)
                 .demand(1)
+                .wrap(null)
                 .argv
             ;
         });
@@ -344,6 +349,7 @@ describe('usage tests', function () {
 
                     return yargs('-f --bar 20'.split(' '))
                         .usage('Usage: $0 [options]', opts)
+                        .wrap(null)
                         .argv;
                 });
                 r.should.have.property('result');
@@ -369,6 +375,7 @@ describe('usage tests', function () {
 
                     return yargs('-f --bar'.split(' '))
                         .usage('Usage: $0 [options]', opts)
+                        .wrap(null)
                         .argv;
                 });
                 r.should.have.property('result');
@@ -397,6 +404,7 @@ describe('usage tests', function () {
                     return yargs('-f --bar 20'.split(' '))
                         .usage('Usage: $0 [options]', opts)
                         .requiresArg(['foo', 'bar'])
+                        .wrap(null)
                         .argv;
                 });
                 r.should.have.property('result');
@@ -426,6 +434,7 @@ describe('usage tests', function () {
                 return yargs('-f 10 --bar 20 --baz 30'.split(' '))
                     .usage('Usage: $0 [options]', opts)
                     .strict()
+                    .wrap(null)
                     .argv;
             });
 
@@ -458,6 +467,7 @@ describe('usage tests', function () {
                 return yargs('-f 10 --bar 20 --baz 30'.split(' '))
                     .usage('Usage: $0 [options]', opts)
                     .strict()
+                    .wrap(null)
                     .argv;
             });
 
@@ -490,6 +500,7 @@ describe('usage tests', function () {
                 return yargs('-f 10 --bar 20 --baz 30 -q 40'.split(' '))
                     .usage('Usage: $0 [options]', opts)
                     .strict()
+                    .wrap(null)
                     .argv;
             });
 
@@ -542,6 +553,7 @@ describe('usage tests', function () {
                 .example("$0 something", "description")
                 .example("$0 something else", "other description")
                 .demand(['y'])
+                .wrap(null)
                 .argv;
         });
         r.should.have.property('result');
@@ -569,6 +581,7 @@ describe('usage tests', function () {
                             'x': { description: 'an option',      demand: true  },
                             'y': { description: 'another option', demand: false }
                         })
+                        .wrap(null)
                         .argv;
                 });
                 r.result.should.have.property('y', 10);
@@ -597,6 +610,7 @@ describe('usage tests', function () {
                             'x': { description: 'an option',      required: true  },
                             'y': { description: 'another option', required: false }
                         })
+                        .wrap(null)
                         .argv;
                 });
                 r.result.should.have.property('y', 10);
@@ -624,6 +638,7 @@ describe('usage tests', function () {
                         'width':  { description: 'Width',  alias: 'w', demand: true  },
                         'height': { description: 'Height', alias: 'h', demand: false }
                     })
+                    .wrap(null)
                     .argv;
             });
             r.result.should.have.property('w', 10);
@@ -639,6 +654,7 @@ describe('usage tests', function () {
                 return yargs(['--help'])
                     .demand(['y'])
                     .help('help')
+                    .wrap(null)
                     .argv;
             });
             r.should.have.property('result');
@@ -661,6 +677,7 @@ describe('usage tests', function () {
                     .help('help')
                     .describe('some-opt', 'Some option')
                     .default('some-opt', 2)
+                    .wrap(null)
                     .argv;
             });
             r.should.have.property('result');
@@ -683,6 +700,7 @@ describe('usage tests', function () {
             var r = checkUsage(function () {
                 return yargs(['--version'])
                     .version('1.0.1', 'version', 'Show version number')
+                    .wrap(null)
                     .argv;
             });
             r.should.have.property('result');
@@ -707,6 +725,7 @@ describe('usage tests', function () {
                     .options(opts)
                     .demand(['foo', 'bar'])
                     .showHelpOnFail(false, "Specify --help for available options")
+                    .wrap(null)
                     .argv;
             });
             r.should.have.property('result');
@@ -734,6 +753,7 @@ describe('usage tests', function () {
                     .usage('Usage: $0 [options]')
                     .options(opts)
                     .demand(['foo'])
+                    .wrap(null)
                     .argv;
             });
             r.should.have.property('result');
@@ -765,7 +785,7 @@ describe('usage tests', function () {
                 return yargs([])
                   .option('fairly-long-option', {
                     alias: 'f',
-                    default: 'fairly long default',
+                    default: 'fairly-long-default',
                     description: 'npm prefix used to locate globally installed npm packages'
                   })
                   .demand('foo')
@@ -780,6 +800,25 @@ describe('usage tests', function () {
             });
         });
 
+        it('should wrap based on window-size if no wrap is provided', function() {
+            var width = require('window-size').width;
+
+            var r = checkUsage(function () {
+                return yargs([])
+                  .option('fairly-long-option', {
+                    alias: 'f',
+                    // create a giant string that should wrap.
+                    description: new Array(width * 5).join('s')
+                  })
+                  .demand('foo')
+                  .argv;
+            });
+
+            // the long description should cause several line
+            // breaks when wrapped.
+            r.errors[0].split('\n').length.should.gt(4);
+        });
+
         it('should not raise an exception when long default and description are provided', function() {
             return yargs([])
               .option('fairly-long-option', {
@@ -789,6 +828,19 @@ describe('usage tests', function () {
               })
               .wrap(40)
               .help()
+        });
+
+        it('should wrap the usage string', function() {
+            var r = checkUsage(function () {
+                return yargs([])
+                  .usage('i am a fairly long usage string look at me go.')
+                  .demand('foo')
+                  .wrap(20)
+                  .argv;
+            });
+
+            // the long usage string should cause line-breaks.
+            r.errors[0].split('\n').length.should.gt(6);
         });
     });
 });

--- a/test/usage.js
+++ b/test/usage.js
@@ -116,6 +116,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
             return yargs('-x 10 -z 20'.split(' '))
                 .usage('Usage: $0 -x NUM -y NUM')
+                .wrap(null)
                 .check(function (argv) {
                     if (!('x' in argv)) throw 'You forgot about -x';
                     if (!('y' in argv)) throw 'You forgot about -y';
@@ -138,6 +139,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
             return yargs('-x 10 -z 20'.split(' '))
                 .usage('Usage: $0 -x NUM -y NUM')
+                .wrap(null)
                 .check(function (argv) {
                     if (!('x' in argv)) return 'You forgot about -x';
                     if (!('y' in argv)) return 'You forgot about -y';
@@ -161,6 +163,7 @@ describe('usage tests', function () {
         var r = checkUsage(function () {
             return yargs('-x 10 -z 20'.split(' '))
                 .usage('Usage: $0 -x NUM -y NUM')
+                .wrap(null)
                 .check(function (argv) {
                     if (!('x' in argv)) return 'You forgot about -x';
                     if (!('y' in argv)) return 'You forgot about -y';
@@ -207,6 +210,7 @@ describe('usage tests', function () {
             return yargs('-x 10 -z 20'.split(' '))
                 .usage('Usage: $0 -x NUM -y NUM')
                 .check(checker)
+                .wrap(null)
                 .argv;
         });
         r.should.have.property('result');
@@ -242,6 +246,7 @@ describe('usage tests', function () {
             return yargs('1 2 --moo'.split(' '))
                 .usage('Usage: $0 [x] [y] [z] {OPTIONS}')
                 .demand(3)
+                .wrap(null)
                 .argv;
         });
         r.should.have.property('result');
@@ -261,6 +266,7 @@ describe('usage tests', function () {
             return yargs('src --moo'.split(' '))
                 .usage('Usage: $0 [x] [y] [z] {OPTIONS} <src> <dest> [extra_files...]')
                 .demand(2, 'src and dest files are both required')
+                .wrap(null)
                 .argv;
         });
         r.should.have.property('result');
@@ -562,11 +568,11 @@ describe('usage tests', function () {
         r.should.have.property('logs').with.length(0);
         r.should.have.property('exit').and.be.ok;
         r.errors.join('\n').split(/\n+/).should.deep.equal([
+            'Options:',
+            '  -y  [required]',
             'Examples:',
             '  ./usage something         description      ',
             '  ./usage something else    other description',
-            'Options:',
-            '  -y  [required]',
             'Missing required arguments: y'
         ]);
     });
@@ -842,5 +848,46 @@ describe('usage tests', function () {
             // the long usage string should cause line-breaks.
             r.errors[0].split('\n').length.should.gt(6);
         });
+    });
+
+    describe('commands', function() {
+      it('should output a list of available commands', function () {
+          var r = checkUsage(function () {
+              return yargs('')
+                  .command("upload", "upload something")
+                  .command("download", "download something from somewhere")
+                  .demand('y')
+                  .wrap(null)
+                  .argv;
+          });
+
+          r.errors.join('\n').split(/\n+/).should.deep.equal([
+              'Commands:',
+              '  upload      upload something                 ',
+              '  download    download something from somewhere',
+              'Options:',
+              '  -y  [required]',
+              'Missing required arguments: y'
+          ]);
+      });
+    });
+
+    describe('epilogue', function() {
+      it('should display an epilog message at the end of the usage instructions', function () {
+          var r = checkUsage(function () {
+              return yargs('')
+                  .epilog("for more info view the manual at http://example.com")
+                  .demand('y')
+                  .wrap(null)
+                  .argv;
+          });
+
+          r.errors.join('\n').split(/\n+/).should.deep.equal([
+              'Options:',
+              '  -y  [required]',
+              'for more info view the manual at http://example.com',
+              'Missing required arguments: y'
+          ]);
+      });
     });
 });

--- a/test/usage.js
+++ b/test/usage.js
@@ -551,7 +551,7 @@ describe('usage tests', function () {
         r.should.have.property('exit').and.be.ok;
         r.errors.join('\n').split(/\n+/).should.deep.equal([
             'Examples:',
-            '  ./usage something         description',
+            '  ./usage something         description      ',
             '  ./usage something else    other description',
             'Options:',
             '  -y  [required]',

--- a/test/usage.js
+++ b/test/usage.js
@@ -100,6 +100,7 @@ describe('usage tests', function () {
                 .check(function (argv) {
                     if (!('x' in argv)) throw 'You forgot about -x';
                     if (!('y' in argv)) throw 'You forgot about -y';
+                    else return true;
                 })
                 .argv;
         });

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -43,6 +43,7 @@ describe('yargs dsl tests', function () {
             x: 'really cool key'
           })
           .demand('x')
+          .wrap(null)
           .argv
       });
 

--- a/test/yargs.js
+++ b/test/yargs.js
@@ -4,7 +4,7 @@ var should = require('chai').should(),
     yargs = require('../'),
     path = require('path');
 
-describe('argv dsl tests', function () {
+describe('yargs dsl tests', function () {
     it('should use bin name for $0, eliminating path', function () {
       process.argv[1] = '/usr/local/bin/ndm';
       process.env._ = '/usr/local/bin/ndm';


### PR DESCRIPTION
## Release Notes

* added the `command` option, which allows you to document the commands that your application accepts:

```
var argv = require('yargs')
  .command('upgrade', 'upgrade the current version of the application')
  .argv;
```

* added the `epilogue` option, which allows you to specify a final line of text that your application should output. see: https://github.com/chevex/yargs/issues/14
* added the `array` option (similar to string, or boolean), tells the parser to always interpret a key as an array, even when only a single value is given.
* version now prints with a newline: see: https://github.com/chevex/yargs/issues/81
* based on @nylen's work, window-size is now detected and is used to wrap usage instructions.
* `.check()` will now fail if any non-truthy value is returned. see: https://github.com/chevex/yargs/issues/76

Version 3.0 features a fairly large refactor, splitting yargs into the `parser`, `validator`, and a `usage` modules.
Long story short, would love people's help hammering on this branch before I merge it.

## Example Output

Here's what CLI output looks like with all the bells and whistles:

```terminal
Usage: node test.js <cmd> [options]

Commands:
  install    install a package (name@version)                     
  publish    publish the package inside the current working
             directory                                            

Options:
  -f, --file, --fil  an array of files        [default: "test.js"]
  -h, --help         display help message                         
  --version, -v      display version information                  
  -q                                                    [required]

Examples:
  npm install npm@latest -g    install the latest version of npm  

for more information visit https://github.com/chevex/yargs

```