### PR TITLE
fix dot-notation logic, surrounding flag variables

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -89,6 +89,7 @@ module.exports = function (args, opts) {
     for (var i = 0; i < args.length; i++) {
         var arg = args[i];
 
+        // -- seperated by =
         if (arg.match(/^--.+=/)) {
             // Using [\s\S] instead of . because js doesn't support the
             // 'dotall' regex modifier. See:
@@ -100,6 +101,7 @@ module.exports = function (args, opts) {
             var key = arg.match(/^--no-(.+)/)[1];
             setArg(key, false);
         }
+        // -- seperated by space.
         else if (arg.match(/^--.+/)) {
             var key = arg.match(/^--(.+)/)[1];
             var next = args[i + 1];
@@ -109,6 +111,24 @@ module.exports = function (args, opts) {
                 i++;
             }
             else if (/^(true|false)$/.test(next)) {
+                setArg(key, next);
+                i++;
+            }
+            else {
+                setArg(key, defaultForType(guessType(key, flags)));
+            }
+        }
+        // dot-notation flag seperated by '='.
+        else if (arg.match(/^-.\..+=/)) {
+            var m = arg.match(/^-([^=]+)=([\s\S]*)$/);
+            setArg(m[1], m[2]);
+        }
+        // dot-notation flag seperated by space.
+        else if (arg.match(/^-.\..+/)) {
+            var key = arg.match(/^-(.\..+)/)[1];
+            var next = args[i + 1];
+            if (next !== undefined && !next.match(/^-/)
+                && !checkAllAliases(key, flags.bools)) {
                 setArg(key, next);
                 i++;
             }

--- a/test/parser.js
+++ b/test/parser.js
@@ -399,6 +399,26 @@ describe('parser tests', function () {
             argv.f.bar.cool.should.eql(11);
             argv.foo.bar.cool.should.eql(11);
         });
+
+        it("should allow flags to use dot notation, when seperated by '='", function () {
+          var argv = yargs(['-f.foo=99'])
+            .argv;
+          argv.f.foo.should.eql(99);
+        });
+
+        it("should allow flags to use dot notation, when seperated by ' '", function () {
+          var argv = yargs(['-f.foo', '99'])
+            .argv;
+          argv.f.foo.should.eql(99);
+        });
+
+        it("should allow flags to use dot notation when no right-hand-side is given", function () {
+          var argv = yargs(['-f.foo', '99', '-f.bar'])
+            .argv;
+
+          argv.f.foo.should.eql(99);
+          argv.f.bar.should.eql(true);
+        });
     })
 
     it('should allow booleans and aliases to be defined with chainable api', function () {


### PR DESCRIPTION
There were various bugs surrounding the usage of dot-notation with flag-style variables:

`-f.bar=33`, see unit-tests for details.